### PR TITLE
Add QuCo-RAG (ACL Findings 2026) to Reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 - \[[arxiv](https://arxiv.org/abs/2402.16893)\] The Good and The Bad: Exploring Privacy Issues in Retrieval-Augmented Generation (RAG). `2024.02`
 
 ### Reliability
+- \[[ACL Findings](https://arxiv.org/abs/2512.19134)\]\[[Github](https://github.com/ZhishanQ/QuCo-RAG)\] QuCo-RAG: Quantifying Uncertainty from the Pre-training Corpus for Dynamic Retrieval-Augmented Generation. `2025.12`
 - \[[AAAI](https://arxiv.org/abs/2410.08985v2)\] Towards Trustworthy Knowledge Graph Reasoning: An Uncertainty Aware Perspective. `2024.10`
 - \[[arxiv](https://arxiv.org/abs/2408.08248)] Conformalized Answer Set Prediction for Knowledge Graph Embedding. `2024.08`
 - \[[ICLR](https://arxiv.org/abs/2306.10193)\] Conformal Language Modeling. `2024.06`


### PR DESCRIPTION
Hi @Arstanley — adding one paper to the **Reliability** section:

**QuCo-RAG: Quantifying Uncertainty from the Pre-training Corpus for Dynamic Retrieval-Augmented Generation** (Findings of ACL 2026)

A dynamic RAG method that quantifies uncertainty using objective pre-training-corpus statistics (via Infini-gram over 4T tokens) instead of unreliable model-internal signals like logits or entropy. Two-stage approach:

1. **Pre-generation:** identifies low-frequency entities → flags long-tail knowledge gaps
2. **Runtime:** verifies entity co-occurrence in the pre-training corpus → zero co-occurrence flags hallucination risk and triggers retrieval

Reduces hallucinations on multi-hop QA (HotpotQA, 2WikiMultihopQA): **+5–12 EM** on OLMo-2 (7B/13B/32B) and **up to +14 EM** on Llama-3 / Qwen2.5 / GPT-4.1 / GPT-5-chat — including models with undisclosed pre-training data. Generalizes to ASQA (long-form) and PubMedQA (biomedical).

Fits naturally in **Reliability** since it directly addresses the calibration/hallucination reliability gap that motivates much of your survey.

- Paper: https://arxiv.org/abs/2512.19134
- Code:  https://github.com/ZhishanQ/QuCo-RAG

Thanks!